### PR TITLE
Add audio-domain tightness comparison tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ conversion-cockpit.bat        # Batch conversion GUI
 trace-viewer.bat input.sid -f 300                       # Interactive HTML trace (frame-by-frame)
 trace-compare.bat file_a.sid file_b.sid                 # Compare two SID traces (tabbed HTML)
 accuracy-heatmap.bat file_a.sid file_b.sid              # Accuracy heatmap (4 viz modes, Canvas)
+audio-tightness.bat orig.sid conv.sf2 --driver-init 0x1000 --driver-play 0x1003  # Onset-timing/attack-shape "tightness" (register-exact != audio-tight)
 batch-analysis.bat originals/ exported/                 # Batch analysis (standalone, HTML+CSV+JSON)
 batch-analysis-validate.bat originals/ exported/        # Batch analysis (validation DB integration)
 validation-dashboard.bat                                # Validation results dashboard

--- a/audio-tightness.bat
+++ b/audio-tightness.bat
@@ -1,0 +1,56 @@
+@echo off
+REM Audio Tightness Tool - Compare onset timing + attack shape between two renders
+REM
+REM Renders an original .sid and a driver .sf2/.sid/.wav to WAV, detects onsets
+REM via spectral flux, aligns them, and reports timing/attack-shape divergence
+REM -- catches audio-domain "not tight" problems that register-write-exact
+REM trace comparison can miss. See docs/guides/AUDIO_TIGHTNESS_GUIDE.md.
+REM
+REM Usage:
+REM   audio-tightness.bat original.sid converted.sf2 --driver-init 0x1000 --driver-play 0x1003
+REM   audio-tightness.bat original.sid converted.sid --voice 1
+REM   audio-tightness.bat a.wav b.wav --no-html
+REM
+REM Options:
+REM   --seconds N              Render duration in seconds (default: 30)
+REM   --voice {1,2,3}          Isolate one SID voice (mutes the other two on BOTH renders)
+REM   --driver-init/--driver-play  Override the driver .sf2's init/play addresses
+REM                            (required for bin/-only native drivers -- see docs)
+REM   --onset-tolerance-ms N   Max onset delta to still count as matched (default: 150)
+REM   --loose-threshold-ms N   Delta above which a matched onset is flagged loose (default: 40)
+REM   --output FILE            Output HTML path
+REM   --text-output FILE       Also write the text report to this path
+REM   --no-html                Skip HTML generation
+REM   -v, -vv                  Verbose logging
+REM   --help                   Show detailed help
+
+setlocal
+
+REM Check Python
+where python >nul 2>nul
+if errorlevel 1 (
+    echo [ERROR] Python not found in PATH
+    echo.
+    echo Please install Python 3.8+ or add to PATH
+    exit /b 1
+)
+
+REM Check arguments
+if "%~1"=="" (
+    echo Audio Tightness Tool - Compare onset timing + attack shape between two renders
+    echo.
+    echo Usage: audio-tightness.bat original.sid converted.sf2 [options]
+    echo.
+    echo Examples:
+    echo   audio-tightness.bat original.sid converted.sf2 --driver-init 0x1000 --driver-play 0x1003
+    echo   audio-tightness.bat original.sid converted.sid --voice 1
+    echo   audio-tightness.bat a.wav b.wav --no-html
+    echo.
+    echo For detailed help: audio-tightness.bat --help
+    exit /b 1
+)
+
+REM Run audio tightness tool
+python pyscript\audio_tightness_tool.py %*
+
+endlocal

--- a/docs/guides/AUDIO_TIGHTNESS_GUIDE.md
+++ b/docs/guides/AUDIO_TIGHTNESS_GUIDE.md
@@ -1,0 +1,255 @@
+# Audio Tightness Tool - User Guide
+
+**Version**: 1.0.0
+**Tool**: `audio-tightness.bat` / `pyscript/audio_tightness_tool.py`
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Quick Start](#quick-start)
+3. [Understanding the Report / HTML Output](#understanding-the-report--html-output)
+4. [Key Metrics Explained](#key-metrics-explained)
+5. [Use Cases](#use-cases)
+6. [Interpreting Results](#interpreting-results)
+7. [Troubleshooting](#troubleshooting)
+8. [Tips & Tricks](#tips--tricks)
+
+---
+
+## Overview
+
+SIDM2's fidelity measurement is almost entirely register-write-exact trace
+comparison (`trace-compare.bat`, `accuracy-heatmap.bat`) — % match on SID
+registers, frame-by-frame. This catches most bugs, but it can hide a real
+gap: during the Blackbird native-driver work, B13 (see
+`docs/players/BLACKBIRD.md`, lines 46/2997-2998) shipped a verified,
+register-exact-match improvement for Glyptodont (97.6% overall — freq 99.5%,
+waveform 95.5%, pulse 99.7%, adsr 96.2%, filter 95.2%), but the user,
+listening to the actual rendered SF2 in the real SID Factory II editor,
+still reported "something with the perc or drums." The register percentage
+never dipped in a way that flagged this — the problem hid inside categories
+(waveform/filter, ~95%) that looked "pretty good" in aggregate.
+
+The **Audio Tightness Tool** measures the audio domain directly: do
+note/drum onsets land at the same time, with the same attack shape, as the
+original? It renders both sides to WAV, detects onsets via spectral flux,
+aligns them, and reports timing/attack-shape divergence — as text (for
+Claude to read directly) and HTML (for a human).
+
+### What It Does
+
+1. **Renders** the original and the driver output to WAV (via SID2WAV —
+   see "Why SID2WAV, not VSID" below)
+2. **Detects onsets** in both renders (numpy spectral-flux + adaptive
+   peak-picking, no external audio library)
+3. **Aligns** onsets between the two renders (greedy nearest-neighbor
+   within a tolerance window)
+4. **Measures** onset-timing delta, attack-rise-time delta, and spectral
+   distance per matched onset
+5. **Reports** a text summary + worst-offenders table, and an HTML
+   waveform view with colored onset markers
+
+### When to Use It
+
+- A register-exact (or near-exact) conversion still "sounds off" to a human
+  listener, and you need a number to reason about instead of a vague
+  impression
+- Investigating drum/percussion tightness specifically (the category most
+  sensitive to onset timing and attack shape)
+- Comparing one SID voice in isolation (`--voice 1/2/3`) to narrow down
+  which channel a "not tight" complaint is actually about
+- As a complement to, **not a replacement for**, `trace-compare.bat` /
+  `accuracy-heatmap.bat` — those catch register-level bugs; this catches
+  what register-level metrics can miss
+
+### Why SID2WAV, not VSID
+
+`sidm2/audio_export_wrapper.py` normally prefers VSID (the VICE emulator)
+over SID2WAV for accuracy. This tool always forces SID2WAV
+(`force_sid2wav=True`), because per-voice isolation (`--voice`) and subtune
+selection (`--subtune`) need SID2WAV-only flags — confirmed directly against
+`tools/SID2WAV.EXE`'s own `-h` output:
+
+```
+-m<num>    mute voices out of 1,2,3,4 (default: none)
+-o<num>    set song number (default: preset)
+```
+
+VICE's `vsid` wrapper (`sidm2/vsid_wrapper.py`) has no equivalent. Both
+sides of a comparison always render through the same tool, so the
+comparison stays apples-to-apples even when voice isolation isn't used.
+
+---
+
+## Quick Start
+
+### Basic Comparison
+
+```bash
+audio-tightness.bat original.sid converted.sid
+```
+
+**Output**: text report on stdout + `audio_tightness_<timestamp>.html`.
+
+### Comparing Against a Native-Driver SF2
+
+Native `bin/`-only drivers (Blackbird, Galway, Romuzak, etc.) each hardcode
+their own init/play addresses, which `scripts/sf2_to_sid.py` **cannot**
+auto-detect (see "Native Drivers" below) — pass them explicitly:
+
+```bash
+audio-tightness.bat original.sid converted.sf2 --driver-init 0x1000 --driver-play 0x1003
+```
+
+### Isolating One Voice
+
+```bash
+audio-tightness.bat original.sid converted.sid --voice 1
+```
+
+`--voice N` mutes the *other two* SID voices (via SID2WAV's `-m<num>`) on
+**both** renders, so voice N can be compared cleanly.
+
+### Common Options
+
+```bash
+--seconds 30                  # Render duration (default: 30)
+--subtune 2                   # Subtune/song number (SID2WAV -o<num>)
+--voice {1,2,3}                # Isolate one SID voice
+--driver-init 0xHHHH           # Override the driver SF2's init address
+--driver-play 0xHHHH           # Override the driver SF2's play address
+--onset-tolerance-ms 150       # Max |delta| to still count as matched (default: 150)
+--loose-threshold-ms 40        # |delta| above which a matched onset is "loose" (default: 40)
+--output report.html           # Output HTML path
+--text-output report.txt       # Also write the text report to a file
+--no-html                      # Skip HTML generation (quick check)
+--keep-temp                    # Keep the temporary rendered .sid/.wav files
+-v, -vv                        # Verbose logging
+```
+
+Both `orig` and `driver` accept `.sid`, `.sf2`, or `.wav` directly — `.wav`
+is used as-is, `.sid` is rendered, `.sf2` is converted to `.sid` first (via
+`scripts/sf2_to_sid.py::convert_sf2_to_sid`) and then rendered.
+
+---
+
+## Understanding the Report / HTML Output
+
+### Text Report
+
+Fixed sections, in order:
+- **Header** — file paths, render params, detector/alignment params
+- **SUMMARY** — onset counts (orig/driver/matched/missing/extra), onset-delta
+  mean/median/max, loose-onset count/%, attack-rise-time delta stats,
+  spectral-distance stats
+- **WORST OFFENDERS** — top 20 matched onsets by `|delta_ms|`
+- **MISSING / EXTRA ONSETS** — onsets present only in the original, or only
+  in the driver render
+
+### HTML Report
+
+- **Overview** — the same summary as the text report, as a table
+- **Waveform** — a downsampled RMS envelope of both renders on a shared
+  time axis, with colored onset markers (green = matched, yellow = matched
+  but loose, red = missing, purple = extra) and hover tooltips
+- **Onset Table** — every matched/missing/extra onset, sortable by column,
+  with a search box
+
+---
+
+## Key Metrics Explained
+
+| Metric | Meaning |
+|---|---|
+| **Matched** | Orig onsets found in the driver render within `--onset-tolerance-ms` |
+| **Missing** | Orig onsets with no driver onset in the tolerance window |
+| **Extra** | Driver onsets with no orig onset in the tolerance window |
+| **Onset delta (ms)** | `driver_t - orig_t` for a matched pair; positive = driver plays late |
+| **Loose** | A matched onset whose `|delta_ms|` exceeds `--loose-threshold-ms` |
+| **Attack rise delta (ms)** | Difference in 10%→90%-of-peak RMS-envelope rise time between the two onsets — a sharper/softer attack than the original |
+| **Spectral distance** | Log-mel distance (24 bands, 200-5000Hz) between the two onsets' first 80ms — a proxy for timbre/waveform difference at the attack |
+
+---
+
+## Use Cases
+
+- **"Register match is 97%+ but it still sounds off"** — run this tool
+  against the full mix first; if loose-onset % or attack-rise delta is
+  elevated, that's a concrete, actionable number instead of "sounds close."
+- **Narrowing down which voice** — run with `--voice 1`, `--voice 2`,
+  `--voice 3` and compare loose-onset % per voice. Treat the result as a
+  hypothesis, not a given — a "drums sound off" complaint doesn't
+  necessarily map cleanly onto a single SID voice.
+- **Regression-checking a fix** — run before/after a driver change on the
+  same file/voice and compare loose-onset % and mean `|delta_ms|`.
+
+---
+
+## Interpreting Results
+
+- **0% loose, low mean |delta_ms|, low spectral distance**: the register
+  match is likely also an audio-tight match — the "not tight" complaint (if
+  any) is probably elsewhere (sustain/release shape, filter sweep, etc. —
+  outside this tool's scope).
+- **High loose %, but missing/extra both ~0%**: onsets exist in the right
+  place but are individually mistimed — a systematic per-note delay or
+  jitter, not a missing/extra-note bug.
+- **Nonzero missing or extra**: either a genuine dropped/added note (check
+  against the register trace with `trace-compare.bat` to confirm) or the
+  onset detector's threshold missed a quiet onset — try tuning
+  `--onset-tolerance-ms` / detector params (see below) before concluding a
+  note is really missing.
+- **Elevated attack-rise delta with low onset-delta**: onsets land on time,
+  but the attack itself is shaped differently (e.g. a filter-cutoff sweep
+  or ADSR envelope difference) — this is exactly the class of gap register
+  percentages can hide inside a "pretty good" aggregate score.
+
+The onset-tolerance/loose-threshold defaults (150ms / 40ms) and the
+detector tuning (`--hop-ms`/`--window-ms`/`--bands`/`--freq-lo`/`--freq-hi`)
+are **provisional** — revisit them once real acceptance runs (see
+`docs/players/BLACKBIRD.md`'s dated entries) give real data points.
+
+---
+
+## Troubleshooting
+
+**`[ERROR] ...init/play addresses could not be auto-detected...`**
+The `.sf2` has no Block 2 header and doesn't match the Laxity heuristics, so
+`scripts/sf2_to_sid.py` would otherwise silently guess Driver 11's
+`$1000/$1006` — wrong for `bin/`-only native drivers (e.g. Blackbird is
+`$1000/$1003`). Pass `--driver-init`/`--driver-play` with the driver's real
+addresses (check the driver's own build script, e.g.
+`bin/build_blackbird_driver_full.py`'s `DRV_INIT`/`DRV_PLAY`).
+
+**`Failed to render ... to WAV: no rendering tool available`**
+`tools/SID2WAV.EXE` isn't present. Install it or run
+`python pyscript/install_vice.py` (note: VSID alone won't help here — voice
+isolation and subtune selection require SID2WAV specifically).
+
+**`Sample rate mismatch`**
+The two renders came out at different sample rates — shouldn't normally
+happen (both go through the same SID2WAV render path), but can occur if one
+side was pre-rendered externally as a `.wav`. Re-render both, or convert
+the mismatched `.wav` to match.
+
+**Detected onset count looks wrong (too many/too few)**
+Tune `--onset-tolerance-ms`, or the underlying detector params
+(`--hop-ms`/`--window-ms`/`--bands`/`--freq-lo`/`--freq-hi`) — these are
+provisional defaults, not tuned against a large corpus yet.
+
+---
+
+## Tips & Tricks
+
+- Use `--no-html --text-output -` (or just omit `--text-output` and read
+  stdout) for a fast Claude-in-the-loop check without generating a browser
+  report every time.
+- `--keep-temp` is useful when iterating on detector params against the
+  same pair — reuse the kept `.wav` files directly as `orig`/`driver`
+  arguments instead of re-rendering.
+- Cross-link: `docs/guides/TRACE_COMPARISON_GUIDE.md` /
+  `docs/guides/ACCURACY_HEATMAP_GUIDE.md` for the register-level complement
+  to this tool; `docs/guides/WAVEFORM_ANALYSIS_GUIDE.md` for the older,
+  human-visual waveform tool (not onset-aware).

--- a/pyscript/audio_tightness_html_exporter.py
+++ b/pyscript/audio_tightness_html_exporter.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""HTML visualization for sidm2.audio_tightness's TightnessReport.
+
+Mirrors accuracy_heatmap_exporter.py's structure: HTMLComponents dark-theme
+header/footer, a StatCard row, a waveform view (downsampled envelope of
+both renders with colored onset markers), and a sortable onset table.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from pyscript.html_components import HTMLComponents, StatCard, StatCardType, NavItem
+from sidm2.audio_tightness import TightnessReport
+
+try:
+    from sidm2 import __version__ as SIDM2_VERSION
+except ImportError:
+    SIDM2_VERSION = "unknown"
+
+
+class AudioTightnessHTMLExporter:
+    """Builds a self-contained HTML tightness report."""
+
+    def __init__(self, report: TightnessReport, meta: Optional[Dict[str, Any]] = None,
+                 orig_env: Optional[Sequence[float]] = None,
+                 driver_env: Optional[Sequence[float]] = None,
+                 env_hop_s: float = 0.01):
+        self.report = report
+        self.meta = meta or {}
+        self.orig_env = list(orig_env) if orig_env is not None else None
+        self.driver_env = list(driver_env) if driver_env is not None else None
+        self.env_hop_s = env_hop_s
+
+    # -- stats -----------------------------------------------------------
+
+    def _counts(self):
+        n_orig = len(self.report.orig_onsets)
+        n_driver = len(self.report.driver_onsets)
+        n_matched = len(self.report.matched)
+        n_missing = len(self.report.missing)
+        n_extra = len(self.report.extra)
+        n_loose = sum(1 for m in self.report.matched if m.loose)
+        return n_orig, n_driver, n_matched, n_missing, n_extra, n_loose
+
+    def _stat_cards(self) -> List[StatCard]:
+        n_orig, n_driver, n_matched, n_missing, n_extra, n_loose = self._counts()
+
+        if self.report.matched:
+            mean_delta = sum(m.delta_ms for m in self.report.matched) / n_matched
+        else:
+            mean_delta = 0.0
+
+        loose_pct = 100.0 * n_loose / n_matched if n_matched else 0.0
+
+        return [
+            StatCard("Matched", str(n_matched), StatCardType.SUCCESS),
+            StatCard("Missing", str(n_missing), StatCardType.ERROR if n_missing else StatCardType.PRIMARY),
+            StatCard("Extra", str(n_extra), StatCardType.WARNING if n_extra else StatCardType.PRIMARY),
+            StatCard("Mean Delta", f"{mean_delta:+.1f} ms", StatCardType.INFO),
+            StatCard("Loose %", f"{loose_pct:.1f}%",
+                     StatCardType.WARNING if loose_pct > 0 else StatCardType.SUCCESS),
+        ]
+
+    # -- sections ----------------------------------------------------------
+
+    def _overview_html(self) -> str:
+        n_orig, n_driver, n_matched, n_missing, n_extra, n_loose = self._counts()
+        rows = [
+            ["Original", self.meta.get('orig_path', '?')],
+            ["Driver", self.meta.get('driver_path', '?')],
+            ["Orig onsets", str(n_orig)],
+            ["Driver onsets", str(n_driver)],
+            ["Matched", str(n_matched)],
+            ["Missing", str(n_missing)],
+            ["Extra", str(n_extra)],
+            ["Loose (of matched)", f"{n_loose} / {n_matched}"],
+        ]
+        for key in sorted(self.report.params.keys()):
+            rows.append([key, str(self.report.params[key])])
+        return HTMLComponents.create_table(["Metric", "Value"], rows)
+
+    def _waveform_html(self) -> str:
+        markers = []
+        for m in self.report.matched:
+            markers.append({
+                'origT': m.orig_t, 'driverT': m.driver_t, 'type': 'loose' if m.loose else 'matched',
+                'deltaMs': m.delta_ms, 'riseDeltaMs': m.rise_delta_ms, 'specDist': m.spectral_dist,
+            })
+        for t in self.report.missing:
+            markers.append({'origT': t, 'driverT': None, 'type': 'missing'})
+        for t in self.report.extra:
+            markers.append({'origT': None, 'driverT': t, 'type': 'extra'})
+
+        data = {
+            'origEnv': self.orig_env or [],
+            'driverEnv': self.driver_env or [],
+            'hopS': self.env_hop_s,
+            'markers': markers,
+        }
+        data_json = json.dumps(data)
+
+        no_env_note = "" if (self.orig_env and self.driver_env) else (
+            '<p style="color:#f09819">No waveform envelope data was supplied -- '
+            'showing onset markers only.</p>'
+        )
+
+        return f"""
+        <div id="waveform-tooltip" style="position:fixed; display:none; background:#252526;
+             border:1px solid #3e3e42; padding:8px 12px; border-radius:4px; font-size:12px;
+             pointer-events:none; z-index:1000;"></div>
+        {no_env_note}
+        <p style="color:#858585; font-size:0.85em; margin-bottom:10px;">
+            Green = matched, Yellow = matched but loose, Red = missing (orig only),
+            Purple = extra (driver only). Hover a marker for details.
+        </p>
+        <canvas id="tightness-waveform-canvas" width="1200" height="260"
+                style="width:100%; max-width:1200px; background:#1e1e1e; border:1px solid #3e3e42;"></canvas>
+        <script>
+        (function() {{
+            const DATA = {data_json};
+            const canvas = document.getElementById('tightness-waveform-canvas');
+            const tooltip = document.getElementById('waveform-tooltip');
+            if (!canvas) return;
+            const ctx = canvas.getContext('2d');
+            const W = canvas.width, H = canvas.height;
+            const midOrig = H * 0.28, midDriver = H * 0.72, ampScale = H * 0.22;
+
+            const maxT = Math.max(
+                DATA.origEnv.length * DATA.hopS,
+                DATA.driverEnv.length * DATA.hopS,
+                ...DATA.markers.map(m => Math.max(m.origT || 0, m.driverT || 0)),
+                1
+            );
+            const xOf = t => (t / maxT) * W;
+
+            function drawEnv(env, mid, color) {{
+                if (!env.length) return;
+                ctx.strokeStyle = color;
+                ctx.beginPath();
+                for (let i = 0; i < env.length; i++) {{
+                    const x = xOf(i * DATA.hopS);
+                    const y = mid - env[i] * ampScale;
+                    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+                }}
+                ctx.stroke();
+            }}
+
+            ctx.fillStyle = '#1e1e1e';
+            ctx.fillRect(0, 0, W, H);
+            ctx.font = '11px monospace';
+            ctx.fillStyle = '#858585';
+            ctx.fillText('original', 4, midOrig - ampScale - 4);
+            ctx.fillText('driver', 4, midDriver - ampScale - 4);
+            drawEnv(DATA.origEnv, midOrig, '#569cd6');
+            drawEnv(DATA.driverEnv, midDriver, '#c586c0');
+
+            const colors = {{matched: '#56ab2f', loose: '#dcdcaa', missing: '#eb3349', extra: '#c586c0'}};
+            const markerXs = [];
+            DATA.markers.forEach(m => {{
+                const color = colors[m.type] || '#d4d4d4';
+                const t = m.origT != null ? m.origT : m.driverT;
+                const x = xOf(t);
+                markerXs.push({{x: x, m: m}});
+                ctx.fillStyle = color;
+                ctx.beginPath();
+                ctx.arc(x, H / 2, 4, 0, 2 * Math.PI);
+                ctx.fill();
+            }});
+
+            canvas.addEventListener('mousemove', function(ev) {{
+                const rect = canvas.getBoundingClientRect();
+                const scaleX = canvas.width / rect.width;
+                const x = (ev.clientX - rect.left) * scaleX;
+                let nearest = null, bestD = 12;
+                markerXs.forEach(entry => {{
+                    const d = Math.abs(entry.x - x);
+                    if (d < bestD) {{ bestD = d; nearest = entry.m; }}
+                }});
+                if (nearest) {{
+                    let lines = ['type: ' + nearest.type];
+                    if (nearest.origT != null) lines.push('orig_t: ' + nearest.origT.toFixed(3) + 's');
+                    if (nearest.driverT != null) lines.push('driver_t: ' + nearest.driverT.toFixed(3) + 's');
+                    if (nearest.deltaMs != null) lines.push('delta_ms: ' + nearest.deltaMs.toFixed(1));
+                    if (nearest.riseDeltaMs != null) lines.push('rise_delta_ms: ' + nearest.riseDeltaMs.toFixed(1));
+                    if (nearest.specDist != null && !isNaN(nearest.specDist)) lines.push('spec_dist: ' + nearest.specDist.toFixed(3));
+                    tooltip.innerHTML = lines.join('<br>');
+                    tooltip.style.left = (ev.clientX + 12) + 'px';
+                    tooltip.style.top = (ev.clientY + 12) + 'px';
+                    tooltip.style.display = 'block';
+                }} else {{
+                    tooltip.style.display = 'none';
+                }}
+            }});
+            canvas.addEventListener('mouseleave', function() {{ tooltip.style.display = 'none'; }});
+        }})();
+        </script>
+"""
+
+    def _onset_table_html(self) -> str:
+        rows_html = []
+        for m in self.report.matched:
+            badge = HTMLComponents.create_badge(
+                "LOOSE" if m.loose else "OK",
+                StatCardType.WARNING if m.loose else StatCardType.SUCCESS
+            )
+            spec = f"{m.spectral_dist:.3f}" if m.spectral_dist == m.spectral_dist else "n/a"
+            rows_html.append(
+                f"<tr><td>{m.orig_t:.3f}</td><td>{m.driver_t:.3f}</td>"
+                f"<td>{m.delta_ms:+.1f}</td><td>{m.rise_delta_ms:+.1f}</td>"
+                f"<td>{spec}</td><td>{badge}</td></tr>"
+            )
+        for t in self.report.missing:
+            badge = HTMLComponents.create_badge("MISSING", StatCardType.ERROR)
+            rows_html.append(f"<tr><td>{t:.3f}</td><td>-</td><td>-</td><td>-</td><td>-</td><td>{badge}</td></tr>")
+        for t in self.report.extra:
+            badge = HTMLComponents.create_badge("EXTRA", StatCardType.INFO)
+            rows_html.append(f"<tr><td>-</td><td>{t:.3f}</td><td>-</td><td>-</td><td>-</td><td>{badge}</td></tr>")
+
+        headers = ["orig_t (s)", "driver_t (s)", "delta_ms", "rise_delta_ms", "spec_dist", "status"]
+        header_cells = ''.join(
+            f'<th style="cursor:pointer" onclick="sortOnsetTable({i})">{h} ⇅</th>'
+            for i, h in enumerate(headers)
+        )
+
+        return f"""
+        {HTMLComponents.create_search_box("Search onsets...", ".onset-row")}
+        <table id="onset-table">
+            <thead><tr>{header_cells}</tr></thead>
+            <tbody>{''.join(rows_html)}</tbody>
+        </table>
+        <script>
+        function sortOnsetTable(colIndex) {{
+            const table = document.getElementById('onset-table');
+            const tbody = table.tBodies[0];
+            const rows = Array.from(tbody.rows);
+            const prevCol = table.getAttribute('data-sort-col');
+            const asc = !(prevCol == colIndex && table.getAttribute('data-sort-dir') === 'asc');
+            rows.sort((a, b) => {{
+                let x = a.cells[colIndex].textContent.trim();
+                let y = b.cells[colIndex].textContent.trim();
+                const nx = parseFloat(x), ny = parseFloat(y);
+                if (!isNaN(nx) && !isNaN(ny)) {{ x = nx; y = ny; }}
+                if (x < y) return asc ? -1 : 1;
+                if (x > y) return asc ? 1 : -1;
+                return 0;
+            }});
+            rows.forEach(r => tbody.appendChild(r));
+            table.setAttribute('data-sort-col', colIndex);
+            table.setAttribute('data-sort-dir', asc ? 'asc' : 'desc');
+        }}
+        </script>
+"""
+
+    # -- top-level -----------------------------------------------------
+
+    def build_html(self) -> str:
+        orig_name = self.meta.get('orig_path', 'original')
+        driver_name = self.meta.get('driver_path', 'driver')
+        title = f"Audio Tightness: {orig_name} vs {driver_name}"
+
+        nav_items = [
+            NavItem("Overview", "overview"),
+            NavItem("Waveform", "waveform"),
+            NavItem("Onset Table", "onset-table-section",
+                    count=len(self.report.matched) + len(self.report.missing) + len(self.report.extra)),
+        ]
+
+        html = HTMLComponents.get_document_header(title)
+        html += '<div class="container">'
+        html += HTMLComponents.create_sidebar("Audio Tightness", nav_items, stats=self._stat_cards())
+
+        html += '<div class="main-content">'
+        html += (
+            f'<div class="header"><h1>Audio Tightness Report</h1>'
+            f'<div class="subtitle">{orig_name} vs {driver_name}</div></div>'
+        )
+        html += HTMLComponents.create_stat_grid(self._stat_cards())
+
+        html += '<div class="section" id="overview"><h2>Overview</h2>' + self._overview_html() + '</div>'
+        html += '<div class="section" id="waveform"><h2>Waveform</h2>' + self._waveform_html() + '</div>'
+        html += (
+            '<div class="section" id="onset-table-section"><h2>Onset Table</h2>'
+            + self._onset_table_html() + '</div>'
+        )
+
+        html += HTMLComponents.create_footer(SIDM2_VERSION, datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+        html += '</div>'  # main-content
+        html += '</div>'  # container
+        html += HTMLComponents.get_document_footer()
+        return html
+
+    def export(self, output_path) -> bool:
+        html = self.build_html()
+        Path(output_path).write_text(html, encoding='utf-8')
+        return True

--- a/pyscript/audio_tightness_report.py
+++ b/pyscript/audio_tightness_report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Text formatter for sidm2.audio_tightness's TightnessReport.
+
+Pure string formatting -- no I/O. Fixed structure (header, SUMMARY, WORST
+OFFENDERS, MISSING/EXTRA), designed to be read directly by Claude as well
+as a human.
+"""
+
+from typing import Any, Dict
+
+import numpy as np
+
+from sidm2.audio_tightness import TightnessReport
+
+
+def _stat_line(label: str, values, signed: bool = True) -> str:
+    if not values:
+        return f"{label}: n/a (no data)"
+    arr = np.asarray(values, dtype=float)
+    fmt = "{:+.1f}" if signed else "{:.1f}"
+    return f"{label}: mean {fmt.format(np.mean(arr))}  median {fmt.format(np.median(arr))}"
+
+
+def format_text_report(report: TightnessReport, meta: Dict[str, Any] = None) -> str:
+    """Render a TightnessReport as a fixed-width text report."""
+    meta = meta or {}
+    lines = []
+
+    lines.append("=" * 80)
+    lines.append("AUDIO TIGHTNESS REPORT")
+    lines.append("=" * 80)
+    lines.append(f"Original: {meta.get('orig_path', '?')}")
+    lines.append(f"Driver:   {meta.get('driver_path', '?')}")
+    if meta.get('voice'):
+        lines.append(f"Voice isolation: voice {meta['voice']} "
+                      f"(muted: {meta.get('mute_voices', '?')})")
+    if meta.get('duration') is not None:
+        lines.append(f"Render duration: {meta['duration']}s")
+
+    lines.append("")
+    lines.append("Detector/alignment params:")
+    for key in sorted(report.params.keys()):
+        lines.append(f"  {key}: {report.params[key]}")
+
+    n_orig = len(report.orig_onsets)
+    n_driver = len(report.driver_onsets)
+    n_matched = len(report.matched)
+    n_missing = len(report.missing)
+    n_extra = len(report.extra)
+
+    match_pct = 100.0 * n_matched / n_orig if n_orig else float('nan')
+    missing_pct = 100.0 * n_missing / n_orig if n_orig else float('nan')
+    extra_pct = 100.0 * n_extra / n_driver if n_driver else float('nan')
+
+    lines.append("")
+    lines.append("-" * 80)
+    lines.append("SUMMARY")
+    lines.append("-" * 80)
+    lines.append(f"Orig onsets:    {n_orig}")
+    lines.append(f"Driver onsets:  {n_driver}")
+    lines.append(f"Matched:        {n_matched} ({match_pct:.1f}% of orig)")
+    lines.append(f"Missing:        {n_missing} ({missing_pct:.1f}% of orig)")
+    lines.append(f"Extra:          {n_extra} ({extra_pct:.1f}% of driver)")
+
+    if report.matched:
+        deltas = [m.delta_ms for m in report.matched]
+        abs_deltas = [abs(d) for d in deltas]
+        loose = [m for m in report.matched if m.loose]
+        rises = [m.rise_delta_ms for m in report.matched]
+        specs = [m.spectral_dist for m in report.matched if m.spectral_dist == m.spectral_dist]
+
+        lines.append("")
+        lines.append(_stat_line("Onset delta (ms)", deltas))
+        lines.append(f"  max |delta_ms|: {max(abs_deltas):.1f}")
+        lines.append(f"Loose onsets:   {len(loose)} / {n_matched} "
+                      f"({100.0 * len(loose) / n_matched:.1f}%)")
+        lines.append(_stat_line("Attack rise delta (ms)", rises))
+        lines.append(_stat_line("Spectral distance", specs, signed=False))
+    else:
+        lines.append("")
+        lines.append("No matched onsets -- nothing to summarize.")
+
+    lines.append("")
+    lines.append("-" * 80)
+    lines.append("WORST OFFENDERS (top 20 by |delta_ms|)")
+    lines.append("-" * 80)
+    worst = sorted(report.matched, key=lambda m: abs(m.delta_ms), reverse=True)[:20]
+    if worst:
+        lines.append(f"{'orig_t':>8}  {'driver_t':>8}  {'delta_ms':>9}  "
+                      f"{'rise_dms':>9}  {'spec_dist':>9}  loose")
+        for m in worst:
+            spec = f"{m.spectral_dist:.3f}" if m.spectral_dist == m.spectral_dist else "n/a"
+            lines.append(
+                f"{m.orig_t:8.3f}  {m.driver_t:8.3f}  {m.delta_ms:+9.1f}  "
+                f"{m.rise_delta_ms:+9.1f}  {spec:>9}  {'YES' if m.loose else ''}"
+            )
+    else:
+        lines.append("(none)")
+
+    lines.append("")
+    lines.append("-" * 80)
+    lines.append(f"MISSING ONSETS (in original, not found in driver): {n_missing}")
+    lines.append("-" * 80)
+    lines.append(", ".join(f"{t:.3f}" for t in report.missing) if report.missing else "(none)")
+
+    lines.append("")
+    lines.append("-" * 80)
+    lines.append(f"EXTRA ONSETS (in driver, not in original): {n_extra}")
+    lines.append("-" * 80)
+    lines.append(", ".join(f"{t:.3f}" for t in report.extra) if report.extra else "(none)")
+
+    lines.append("=" * 80)
+    return "\n".join(lines)

--- a/pyscript/audio_tightness_tool.py
+++ b/pyscript/audio_tightness_tool.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+Audio Tightness Tool - Compare onset timing + attack shape between two renders
+
+Register-write-exact trace comparison (trace_comparison_tool.py,
+accuracy_heatmap_tool.py) can miss audio-domain "tightness" problems that a
+human ear catches immediately -- see docs/guides/AUDIO_TIGHTNESS_GUIDE.md for
+the motivating case (docs/players/BLACKBIRD.md's B13 entry). This tool
+renders both sides to WAV, detects onsets via spectral flux, aligns them, and
+reports timing/attack-shape divergence as text (for Claude) and HTML (for a
+human).
+
+Usage:
+    python audio_tightness_tool.py original.sid converted.sf2 --driver-init 0x1000 --driver-play 0x1003
+    python audio_tightness_tool.py original.sid converted.sid --voice 1
+    python audio_tightness_tool.py a.wav b.wav --no-html
+
+Version: 1.0.0
+"""
+
+import argparse
+import logging
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.sf2_to_sid import SF2File, convert_sf2_to_sid
+from sidm2.audio_export_wrapper import AudioExportIntegration
+from sidm2.audio_tightness import analyze_tightness_files, load_wav_mono
+from pyscript.audio_tightness_report import format_text_report
+from pyscript.audio_tightness_html_exporter import AudioTightnessHTMLExporter
+
+MUTE_MAP = {1: "23", 2: "13", 3: "12"}
+
+
+def setup_logging(verbose: int):
+    """Setup logging based on verbosity level"""
+    if verbose >= 2:
+        level = logging.DEBUG
+    elif verbose >= 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level, format='[%(levelname)s] %(message)s')
+
+
+def _hex_or_int(s: str) -> int:
+    return int(s, 0)
+
+
+def _render(sid_path, out_wav, seconds, subtune, voice, verbose):
+    """Render a .sid to .wav via SID2WAV (always -- mute/subtune have no VSID
+    equivalent, and both sides must use the same tool for an apples-to-apples
+    comparison)."""
+    mute_voices = MUTE_MAP.get(voice) if voice else None
+    result = AudioExportIntegration.export_to_wav(
+        sid_file=Path(sid_path), output_file=Path(out_wav),
+        duration=int(seconds), verbose=verbose,
+        force_sid2wav=True, mute_voices=mute_voices, subtune=subtune,
+    )
+    if not result or not result.get('success'):
+        err = result.get('error') if result else 'no rendering tool available'
+        raise RuntimeError(f"Failed to render {sid_path} to WAV: {err}")
+    return out_wav
+
+
+def resolve_input(path: Path, role: str, args, tmp_dir: Path):
+    """Resolve a .sid/.sf2/.wav CLI arg to a WAV file, rendering as needed.
+    Returns None (after printing [ERROR]) on failure."""
+    ext = path.suffix.lower()
+
+    if ext == '.wav':
+        return path
+
+    if ext == '.sf2':
+        data = path.read_bytes()
+        sf2 = SF2File(data)
+        if sf2.address_source == 'default_guess' and args.driver_init is None and args.driver_play is None:
+            print(
+                f"[ERROR] {path}: init/play addresses could not be auto-detected "
+                f"(SF2 has no Block 2 header and doesn't match the Laxity heuristics, "
+                f"so this fell back to the Driver 11 default guess -- WRONG for any "
+                f"bin/-only native driver). Pass --driver-init/--driver-play with the "
+                f"driver's real addresses."
+            )
+            return None
+
+        tmp_sid = tmp_dir / f"{role}.sid"
+        if not convert_sf2_to_sid(str(path), str(tmp_sid),
+                                   init_override=args.driver_init, play_override=args.driver_play):
+            print(f"[ERROR] Failed to convert {path} to SID")
+            return None
+        out_wav = tmp_dir / f"{role}.wav"
+        return _render(tmp_sid, out_wav, args.seconds, args.subtune, args.voice, args.verbose)
+
+    if ext == '.sid':
+        out_wav = tmp_dir / f"{role}.wav"
+        return _render(path, out_wav, args.seconds, args.subtune, args.voice, args.verbose)
+
+    print(f"[ERROR] Unsupported file extension for {path}: {ext!r} (expected .sid, .sf2, or .wav)")
+    return None
+
+
+def _downsample_envelope(x: np.ndarray, sr: int, hop_s: float):
+    """Peak-normalized RMS envelope at hop_s resolution, for the HTML waveform view."""
+    hop = max(1, int(round(hop_s * sr)))
+    win = hop
+    n = max(0, (len(x) - win) // hop + 1)
+    env = np.zeros(n)
+    for i in range(n):
+        seg = x[i * hop: i * hop + win]
+        if seg.size:
+            env[i] = np.sqrt(np.mean(seg.astype(np.float64) ** 2))
+    peak = env.max() if env.size else 0.0
+    if peak > 0:
+        env = env / peak
+    return env.tolist()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare audio-domain 'tightness' (onset timing + attack shape) "
+                     "between an original SID and a converted driver render",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  %(prog)s original.sid converted.sf2 --driver-init 0x1000 --driver-play 0x1003
+  %(prog)s original.sid converted.sid --voice 1
+  %(prog)s a.wav b.wav --no-html
+
+Output:
+  Text report (stdout, or --text-output FILE): onset match/missing/extra
+  counts, onset-delta and attack-rise-time statistics, worst-offenders table.
+  Designed to be read directly by Claude.
+  HTML report (unless --no-html): waveform view with colored onset markers
+  and a sortable onset table, for human review.
+
+Voice isolation:
+  --voice {1,2,3} mutes the OTHER two SID voices (SID2WAV's -m<num>) on BOTH
+  renders, so a single channel can be compared cleanly. Renders always use
+  SID2WAV (not VSID), since VSID has no mute/subtune equivalent.
+
+Native drivers (bin/-only, e.g. Blackbird):
+  --driver-init/--driver-play are REQUIRED when the .sf2's init/play
+  addresses can't be auto-detected -- the tool refuses to guess, since the
+  Driver-11 default guess is wrong for these (see docs/guides/AUDIO_TIGHTNESS_GUIDE.md).
+        '''
+    )
+
+    parser.add_argument('orig', help="Original .sid/.wav file")
+    parser.add_argument('driver', help="Driver-rendered .sf2/.sid/.wav file to compare against")
+
+    parser.add_argument('--seconds', type=float, default=30,
+                         help="Render duration in seconds (default: 30)")
+    parser.add_argument('--subtune', type=int, default=None,
+                         help="Subtune/song number (SID2WAV -o<num>)")
+    parser.add_argument('--voice', type=int, choices=[1, 2, 3], default=None,
+                         help="Isolate one SID voice by muting the other two on BOTH renders")
+    parser.add_argument('--driver-init', type=_hex_or_int, default=None,
+                         help="Override the driver SF2's init address (e.g. 0x1000)")
+    parser.add_argument('--driver-play', type=_hex_or_int, default=None,
+                         help="Override the driver SF2's play address (e.g. 0x1003)")
+
+    parser.add_argument('--onset-tolerance-ms', type=float, default=150,
+                         help="Max |delta| to still count as a matched onset (default: 150)")
+    parser.add_argument('--loose-threshold-ms', type=float, default=40,
+                         help="|delta| above which a matched onset is flagged loose (default: 40)")
+    parser.add_argument('--hop-ms', type=float, default=10, help="Onset detector hop size (default: 10)")
+    parser.add_argument('--window-ms', type=float, default=40, help="Onset detector window size (default: 40)")
+    parser.add_argument('--bands', type=int, default=40, help="Onset detector band count (default: 40)")
+    parser.add_argument('--freq-lo', type=float, default=30, help="Onset detector band low edge Hz (default: 30)")
+    parser.add_argument('--freq-hi', type=float, default=8000, help="Onset detector band high edge Hz (default: 8000)")
+
+    parser.add_argument('-o', '--output', default=None,
+                         help="Output HTML path (default: audio_tightness_<timestamp>.html)")
+    parser.add_argument('--text-output', default=None, help="Also write the text report to this path")
+    parser.add_argument('--no-html', action='store_true', help="Skip HTML generation")
+    parser.add_argument('--keep-temp', action='store_true', help="Keep temporary rendered .sid/.wav files")
+
+    parser.add_argument('-v', '--verbose', action='count', default=0, help="Increase verbosity (-v, -vv)")
+
+    args = parser.parse_args()
+    setup_logging(args.verbose)
+
+    orig_path = Path(args.orig)
+    driver_path = Path(args.driver)
+
+    if not orig_path.exists():
+        print(f"[ERROR] File not found: {args.orig}")
+        return 1
+    if not driver_path.exists():
+        print(f"[ERROR] File not found: {args.driver}")
+        return 1
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="audio_tightness_"))
+    try:
+        print(f"\nResolving original: {args.orig}")
+        try:
+            orig_wav = resolve_input(orig_path, 'orig', args, tmp_dir)
+        except RuntimeError as e:
+            print(f"[ERROR] {e}")
+            return 1
+        if orig_wav is None:
+            return 1
+        print(f"  [OK] {orig_wav}")
+
+        print(f"\nResolving driver: {args.driver}")
+        try:
+            driver_wav = resolve_input(driver_path, 'driver', args, tmp_dir)
+        except RuntimeError as e:
+            print(f"[ERROR] {e}")
+            return 1
+        if driver_wav is None:
+            return 1
+        print(f"  [OK] {driver_wav}")
+
+        print("\nAnalyzing tightness...")
+        try:
+            report = analyze_tightness_files(
+                orig_wav, driver_wav,
+                onset_tolerance_ms=args.onset_tolerance_ms,
+                loose_threshold_ms=args.loose_threshold_ms,
+                hop_ms=args.hop_ms, window_ms=args.window_ms, bands=args.bands,
+                freq_lo=args.freq_lo, freq_hi=args.freq_hi,
+            )
+        except Exception as e:
+            print(f"[ERROR] Analysis failed: {e}")
+            if args.verbose >= 2:
+                import traceback
+                traceback.print_exc()
+            return 1
+
+        meta = dict(
+            orig_path=args.orig, driver_path=args.driver, duration=args.seconds,
+            voice=args.voice, mute_voices=MUTE_MAP.get(args.voice) if args.voice else None,
+        )
+
+        text_report = format_text_report(report, meta)
+        print("\n" + text_report)
+
+        if args.text_output:
+            Path(args.text_output).write_text(text_report, encoding='utf-8')
+            print(f"\n[OK] Text report written: {args.text_output}")
+
+        if not args.no_html:
+            if args.output:
+                output_path = args.output
+            else:
+                timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+                output_path = f"audio_tightness_{timestamp}.html"
+
+            print(f"\nGenerating HTML report: {output_path}")
+            try:
+                orig_audio, orig_sr = load_wav_mono(orig_wav)
+                driver_audio, driver_sr = load_wav_mono(driver_wav)
+                env_hop_s = 0.02
+                orig_env = _downsample_envelope(orig_audio, orig_sr, env_hop_s)
+                driver_env = _downsample_envelope(driver_audio, driver_sr, env_hop_s)
+
+                exporter = AudioTightnessHTMLExporter(
+                    report, meta, orig_env=orig_env, driver_env=driver_env, env_hop_s=env_hop_s
+                )
+                if exporter.export(output_path):
+                    file_size = Path(output_path).stat().st_size
+                    print(f"[OK] HTML report generated: {output_path}")
+                    print(f"     Size: {file_size:,} bytes")
+                else:
+                    print("[ERROR] Failed to generate HTML report")
+                    return 1
+            except Exception as e:
+                print(f"[ERROR] Failed to export HTML: {e}")
+                if args.verbose >= 2:
+                    import traceback
+                    traceback.print_exc()
+                return 1
+
+        return 0
+    finally:
+        if args.keep_temp:
+            print(f"\n[INFO] Temp render files kept: {tmp_dir}")
+        else:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pyscript/test_audio_tightness.py
+++ b/pyscript/test_audio_tightness.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Unit Tests for sidm2.audio_tightness
+
+Tests the pure numpy onset-detection / alignment / attack-shape functions
+against synthetic click-track fixtures -- no VICE/SID2WAV needed, runs in
+the normal pytest suite.
+
+Usage:
+    python -m pytest pyscript/test_audio_tightness.py -v
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sidm2.audio_tightness import (
+    align_onsets,
+    analyze_tightness,
+    attack_rise_time_ms,
+    detect_onsets,
+    logmel_distance,
+)
+
+SR = 44100
+
+
+def _make_click_track(sr, duration_s, click_times_s, kind='exp', amp=1.0, decay=0.02, seed=0):
+    """Synthetic click track: decaying noise bursts (percussive) at each
+    given time. kind='exp' = sharp exponential-decay onset (step-like
+    attack); kind='ramp' = a linear fade-in before the same decay."""
+    n = int(round(duration_s * sr))
+    x = np.zeros(n)
+    rng = np.random.RandomState(seed)
+    burst_len = int(decay * sr)
+    noise = rng.uniform(-1, 1, burst_len)
+    decay_env = np.exp(-np.arange(burst_len) / (decay * sr / 5))
+
+    for t in click_times_s:
+        start = int(round(t * sr))
+        env = decay_env.copy()
+        if kind == 'ramp':
+            ramp_len = max(1, burst_len // 4)
+            env = env.copy()
+            env[:ramp_len] *= np.linspace(0, 1, ramp_len)
+        end = min(n, start + burst_len)
+        x[start:end] += amp * env[:end - start] * noise[:end - start]
+    return x
+
+
+class TestOnsetDetection(unittest.TestCase):
+    def test_single_click_onset_time_accuracy(self):
+        x = _make_click_track(SR, 1.0, [0.3])
+        onsets = detect_onsets(x, SR)
+        self.assertEqual(len(onsets), 1)
+        self.assertAlmostEqual(onsets[0], 0.3, delta=0.02)
+
+    def test_steady_tone_produces_no_false_onsets(self):
+        n = int(SR * 1.0)
+        tone = 0.3 * np.sin(2 * np.pi * 440 * np.arange(n) / SR)
+        onsets = detect_onsets(tone, SR)
+        self.assertEqual(onsets, [])
+
+    def test_multiple_clicks_all_detected(self):
+        click_times = [0.2, 0.6, 1.0, 1.4]
+        x = _make_click_track(SR, 2.0, click_times)
+        onsets = detect_onsets(x, SR)
+        self.assertEqual(len(onsets), len(click_times))
+        for expected, actual in zip(click_times, onsets):
+            self.assertAlmostEqual(expected, actual, delta=0.025)
+
+
+class TestAlignment(unittest.TestCase):
+    def test_identical_tracks_align_fully(self):
+        onsets = [0.1, 0.5, 0.9]
+        pairs, missing, extra = align_onsets(onsets, list(onsets), tolerance_s=0.15)
+        self.assertEqual(len(pairs), 3)
+        self.assertEqual(missing, [])
+        self.assertEqual(extra, [])
+
+    def test_missing_and_extra_land_in_right_bucket(self):
+        orig = [0.1, 0.5, 0.9]
+        driver = [0.1, 0.9, 1.3]
+        pairs, missing, extra = align_onsets(orig, driver, tolerance_s=0.05)
+        self.assertEqual([p[0] for p in pairs], [0.1, 0.9])
+        self.assertEqual(missing, [0.5])
+        self.assertEqual(extra, [1.3])
+
+    def test_missing_not_misaligned_to_a_neighbor(self):
+        # A dropped onset must NOT silently steal a distant, unrelated
+        # driver onset just because it's the closest one outside tolerance.
+        orig = [0.1, 0.5, 0.9]
+        driver = [0.1, 0.9]
+        pairs, missing, extra = align_onsets(orig, driver, tolerance_s=0.05)
+        self.assertEqual(missing, [0.5])
+        self.assertEqual([p[1] for p in pairs], [0.1, 0.9])
+
+
+class TestToleranceBoundary(unittest.TestCase):
+    def test_shifted_click_flagged_loose_or_not_at_threshold(self):
+        click_times = [0.5]
+        x = _make_click_track(SR, 1.5, click_times)
+
+        # Just inside the loose threshold.
+        y_tight = _make_click_track(SR, 1.5, [click_times[0] + 0.03])
+        report_tight = analyze_tightness(x, y_tight, SR, onset_tolerance_ms=150,
+                                          loose_threshold_ms=40)
+        self.assertEqual(len(report_tight.matched), 1)
+        self.assertFalse(report_tight.matched[0].loose)
+
+        # Clearly past the loose threshold.
+        y_loose = _make_click_track(SR, 1.5, [click_times[0] + 0.08])
+        report_loose = analyze_tightness(x, y_loose, SR, onset_tolerance_ms=150,
+                                          loose_threshold_ms=40)
+        self.assertEqual(len(report_loose.matched), 1)
+        self.assertTrue(report_loose.matched[0].loose)
+
+    def test_onset_outside_tolerance_window_is_missing_not_matched(self):
+        x = _make_click_track(SR, 1.5, [0.5])
+        y = _make_click_track(SR, 1.5, [0.5 + 0.2])
+        report = analyze_tightness(x, y, SR, onset_tolerance_ms=150, loose_threshold_ms=40)
+        self.assertEqual(report.matched, [])
+        self.assertEqual(len(report.missing), 1)
+        self.assertEqual(len(report.extra), 1)
+
+
+class TestAttackRiseTime(unittest.TestCase):
+    def test_ramp_onset_has_longer_rise_than_step_onset(self):
+        n = int(SR * 0.5)
+        onset_sample = 100
+        onset_t = onset_sample / SR
+
+        x_step = np.zeros(n)
+        x_step[onset_sample:] = np.sin(2 * np.pi * 440 * np.arange(n - onset_sample) / SR)
+
+        ramp_len = int(0.03 * SR)
+        x_ramp = np.zeros(n)
+        env = np.linspace(0, 1, ramp_len)
+        x_ramp[onset_sample:onset_sample + ramp_len] = (
+            env * np.sin(2 * np.pi * 440 * np.arange(ramp_len) / SR)
+        )
+        x_ramp[onset_sample + ramp_len:] = np.sin(
+            2 * np.pi * 440 * np.arange(n - onset_sample - ramp_len) / SR
+        )
+
+        rise_step = attack_rise_time_ms(x_step, SR, onset_t)
+        rise_ramp = attack_rise_time_ms(x_ramp, SR, onset_t)
+        self.assertGreater(rise_ramp, rise_step)
+
+    def test_silence_returns_zero_rise_time(self):
+        x = np.zeros(int(SR * 0.2))
+        self.assertEqual(attack_rise_time_ms(x, SR, 0.05), 0.0)
+
+
+class TestLogmelDistance(unittest.TestCase):
+    def test_identical_segments_have_zero_distance(self):
+        n = 2000
+        seg = np.sin(2 * np.pi * 440 * np.arange(n) / SR)
+        self.assertAlmostEqual(logmel_distance(seg, seg, SR), 0.0, places=9)
+
+    def test_different_timbres_have_nonzero_distance(self):
+        n = 2000
+        seg_a = np.sin(2 * np.pi * 440 * np.arange(n) / SR)
+        seg_b = np.sin(2 * np.pi * 2000 * np.arange(n) / SR)
+        self.assertGreater(logmel_distance(seg_a, seg_b, SR), 0.0)
+
+
+class TestSummaryStats(unittest.TestCase):
+    def test_hand_computed_summary_matches(self):
+        orig_times = [0.2, 0.6, 1.0]
+        x = _make_click_track(SR, 1.5, orig_times)
+        driver_times = [0.2, 0.61, 1.3]  # 0.6->0.61 (10ms, tight), 1.0 missing, 1.3 extra
+        y = _make_click_track(SR, 1.5, driver_times)
+
+        report = analyze_tightness(x, y, SR, onset_tolerance_ms=150, loose_threshold_ms=40)
+
+        self.assertEqual(len(report.orig_onsets), 3)
+        self.assertEqual(len(report.driver_onsets), 3)
+        self.assertEqual(len(report.matched), 2)
+        self.assertEqual(len(report.missing), 1)
+        self.assertEqual(len(report.extra), 1)
+
+        deltas = sorted(abs(m.delta_ms) for m in report.matched)
+        self.assertAlmostEqual(deltas[0], 0.0, delta=5.0)
+        self.assertAlmostEqual(deltas[1], 10.0, delta=5.0)
+        self.assertTrue(all(not m.loose for m in report.matched))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyscript/test_audio_tightness_html_exporter.py
+++ b/pyscript/test_audio_tightness_html_exporter.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit Tests for pyscript.audio_tightness_html_exporter
+
+No browser needed -- asserts well-formed HTML and presence of expected
+content strings, mirroring test_sidwinder_html_exporter.py's pattern.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pyscript.audio_tightness_html_exporter import AudioTightnessHTMLExporter
+from sidm2.audio_tightness import Onset, OnsetMatch, TightnessReport
+
+
+def _make_report():
+    matched = [
+        OnsetMatch(orig_t=0.18, driver_t=0.18, delta_ms=0.0, rise_delta_ms=0.5,
+                   spectral_dist=0.01, loose=False),
+        OnsetMatch(orig_t=0.58, driver_t=0.63, delta_ms=50.0, rise_delta_ms=1.2,
+                   spectral_dist=0.2, loose=True),
+    ]
+    return TightnessReport(
+        orig_onsets=[Onset(t=0.18), Onset(t=0.58), Onset(t=0.98)],
+        driver_onsets=[Onset(t=0.18), Onset(t=0.63), Onset(t=1.4)],
+        matched=matched,
+        missing=[0.98],
+        extra=[1.4],
+        params={'onset_tolerance_ms': 150, 'loose_threshold_ms': 40},
+    )
+
+
+class TestAudioTightnessHTMLExporter(unittest.TestCase):
+    def setUp(self):
+        self.report = _make_report()
+        self.meta = {'orig_path': 'orig.sid', 'driver_path': 'driver.sf2'}
+
+    def test_well_formed_html(self):
+        html = AudioTightnessHTMLExporter(self.report, self.meta).build_html()
+        self.assertIn('<!DOCTYPE html>', html)
+        self.assertIn('<html', html)
+        self.assertIn('</html>', html)
+        self.assertIn('<script>', html)
+
+    def test_file_names_present(self):
+        html = AudioTightnessHTMLExporter(self.report, self.meta).build_html()
+        self.assertIn('orig.sid', html)
+        self.assertIn('driver.sf2', html)
+
+    def test_stat_labels_present(self):
+        html = AudioTightnessHTMLExporter(self.report, self.meta).build_html()
+        for label in ("Matched", "Missing", "Extra", "Mean Delta", "Loose"):
+            self.assertIn(label, html)
+
+    def test_stat_values_present(self):
+        html = AudioTightnessHTMLExporter(self.report, self.meta).build_html()
+        # 2 matched, 1 missing, 1 extra (see _make_report)
+        self.assertIn('>2<', html)
+        self.assertIn('>1<', html)
+
+    def test_onset_table_rows_present(self):
+        html = AudioTightnessHTMLExporter(self.report, self.meta).build_html()
+        self.assertIn('0.180', html)
+        self.assertIn('0.630', html)
+        self.assertIn('sortOnsetTable', html)
+
+    def test_waveform_section_present_without_env_data(self):
+        html = AudioTightnessHTMLExporter(self.report, self.meta).build_html()
+        self.assertIn('tightness-waveform-canvas', html)
+        self.assertIn('No waveform envelope data', html)
+
+    def test_waveform_section_uses_env_data_when_provided(self):
+        html = AudioTightnessHTMLExporter(
+            self.report, self.meta, orig_env=[0.1, 0.5, 0.2], driver_env=[0.1, 0.4, 0.3]
+        ).build_html()
+        self.assertNotIn('No waveform envelope data', html)
+        self.assertIn('origEnv', html)
+        self.assertIn('driverEnv', html)
+
+    def test_empty_report_does_not_crash(self):
+        empty = TightnessReport(orig_onsets=[], driver_onsets=[], matched=[], missing=[], extra=[], params={})
+        html = AudioTightnessHTMLExporter(empty, {}).build_html()
+        self.assertIn('<!DOCTYPE html>', html)
+        self.assertIn('</html>', html)
+
+    def test_export_writes_file(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "report.html"
+            exporter = AudioTightnessHTMLExporter(self.report, self.meta)
+            self.assertTrue(exporter.export(out))
+            self.assertTrue(out.exists())
+            content = out.read_text(encoding='utf-8')
+            self.assertIn('<!DOCTYPE html>', content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyscript/test_audio_tightness_report.py
+++ b/pyscript/test_audio_tightness_report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Unit Tests for pyscript.audio_tightness_report
+
+Checks the text report's fixed structure and that expected values appear,
+using hand-built TightnessReport fixtures (no rendering/analysis needed).
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pyscript.audio_tightness_report import format_text_report
+from sidm2.audio_tightness import Onset, OnsetMatch, TightnessReport
+
+
+def _make_report():
+    matched = [
+        OnsetMatch(orig_t=0.18, driver_t=0.18, delta_ms=0.0, rise_delta_ms=0.5,
+                   spectral_dist=0.01, loose=False),
+        OnsetMatch(orig_t=0.58, driver_t=0.63, delta_ms=50.0, rise_delta_ms=1.2,
+                   spectral_dist=0.2, loose=True),
+    ]
+    return TightnessReport(
+        orig_onsets=[Onset(t=0.18), Onset(t=0.58), Onset(t=0.98)],
+        driver_onsets=[Onset(t=0.18), Onset(t=0.63), Onset(t=1.4)],
+        matched=matched,
+        missing=[0.98],
+        extra=[1.4],
+        params={'onset_tolerance_ms': 150, 'loose_threshold_ms': 40},
+    )
+
+
+class TestFormatTextReport(unittest.TestCase):
+    def setUp(self):
+        self.report = _make_report()
+
+    def test_has_expected_section_headers(self):
+        text = format_text_report(self.report, {'orig_path': 'a.sid', 'driver_path': 'b.sf2'})
+        for header in ("AUDIO TIGHTNESS REPORT", "SUMMARY", "WORST OFFENDERS",
+                       "MISSING ONSETS", "EXTRA ONSETS"):
+            self.assertIn(header, text)
+
+    def test_file_paths_present(self):
+        text = format_text_report(self.report, {'orig_path': 'orig.sid', 'driver_path': 'drv.sf2'})
+        self.assertIn('orig.sid', text)
+        self.assertIn('drv.sf2', text)
+
+    def test_counts_present(self):
+        text = format_text_report(self.report, {})
+        self.assertIn("Orig onsets:    3", text)
+        self.assertIn("Driver onsets:  3", text)
+        self.assertIn("Matched:        2", text)
+        self.assertIn("Missing:        1", text)
+        self.assertIn("Extra:          1", text)
+
+    def test_loose_count_present(self):
+        text = format_text_report(self.report, {})
+        self.assertIn("Loose onsets:   1 / 2", text)
+
+    def test_worst_offender_delta_present(self):
+        text = format_text_report(self.report, {})
+        self.assertIn("+50.0", text)
+
+    def test_missing_and_extra_times_listed(self):
+        text = format_text_report(self.report, {})
+        self.assertIn("0.980", text)
+        self.assertIn("1.400", text)
+
+    def test_no_matches_handled_gracefully(self):
+        empty = TightnessReport(
+            orig_onsets=[Onset(t=0.1)], driver_onsets=[], matched=[],
+            missing=[0.1], extra=[], params={},
+        )
+        text = format_text_report(empty, {})
+        self.assertIn("No matched onsets", text)
+        self.assertIn("(none)", text)  # worst-offenders table empty
+
+    def test_voice_and_duration_meta_shown(self):
+        text = format_text_report(self.report, {'voice': 2, 'mute_voices': '13', 'duration': 30})
+        self.assertIn("voice 2", text)
+        self.assertIn("30s", text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@
 # GUI Dependencies (optional - only needed for Conversion Cockpit and SF2 Viewer)
 PyQt6>=6.6.0
 PyQt6-WebEngine>=6.6.0  # For embedded dashboard view in Conversion Cockpit
+
+# Audio analysis (audio_tightness_tool.py / sidm2.audio_tightness)
+numpy>=1.24

--- a/scripts/sf2_to_sid.py
+++ b/scripts/sf2_to_sid.py
@@ -126,6 +126,7 @@ class SF2File:
         self.load_address = None
         self.init_address = None
         self.play_address = None
+        self.address_source = None
         self.title = ""
         self.author = ""
         self.copyright = ""
@@ -216,6 +217,7 @@ class SF2File:
                                 self.init_address = struct.unpack('<H', self.data[block_data_offset:block_data_offset+2])[0]
                                 # Skip stop address at +2/+3
                                 self.play_address = struct.unpack('<H', self.data[block_data_offset+4:block_data_offset+6])[0]
+                                self.address_source = 'block2'
                                 logger.debug(f"  Parsed Block 2 (DriverCommon): init=${self.init_address:04X}, play=${self.play_address:04X}")
                                 return
 
@@ -231,6 +233,7 @@ class SF2File:
             # Laxity driver detected via load address
             self.init_address = 0x0D7E
             self.play_address = 0x0D81
+            self.address_source = 'laxity_load_addr'
             logger.debug(f"  Detected Laxity driver (load=$0D7E): init=$0D7E, play=$0D81")
             return
 
@@ -240,12 +243,14 @@ class SF2File:
             if b'Laxity' in header_text:
                 self.init_address = 0x0D80
                 self.play_address = 0x0D83
+                self.address_source = 'laxity_string'
                 logger.debug(f"  Detected Laxity driver (string match): init=$0D80, play=$0D83")
                 return
 
         # Default: Driver 11 entry points
         self.init_address = 0x1000
         self.play_address = 0x1006
+        self.address_source = 'default_guess'
         logger.debug(f"  Using Driver 11 default entry points: init=$1000, play=$1006")
 
     def get_prg_data(self) -> bytes:
@@ -257,13 +262,17 @@ class SF2File:
         return self.data[2:]
 
 
-def convert_sf2_to_sid(sf2_path: str, sid_path: str) -> bool:
+def convert_sf2_to_sid(sf2_path: str, sid_path: str,
+                        init_override: Optional[int] = None,
+                        play_override: Optional[int] = None) -> bool:
     """
     Convert SF2 file to PSID format
 
     Args:
         sf2_path: Path to input .sf2 file
         sid_path: Path to output .sid file
+        init_override: Explicit init address, overrides detected address
+        play_override: Explicit play address, overrides detected address
 
     Returns:
         True if conversion successful
@@ -300,6 +309,21 @@ def convert_sf2_to_sid(sf2_path: str, sid_path: str) -> bool:
         )
 
     sf2 = SF2File(sf2_data)
+
+    if init_override is not None:
+        sf2.init_address = init_override
+    if play_override is not None:
+        sf2.play_address = play_override
+
+    if sf2.address_source == 'default_guess' and init_override is None and play_override is None:
+        logger.warning(
+            f"  Init/play addresses could not be detected from the SF2 header "
+            f"or Laxity heuristics; falling back to the Driver 11 default guess "
+            f"(init=${sf2.init_address:04X}, play=${sf2.play_address:04X}). "
+            f"This is WRONG for any bin/-only native driver (e.g. Blackbird uses "
+            f"init=$1000/play=$1003, not $1006). Pass --init/--play "
+            f"(or init_override/play_override) with the driver's real addresses."
+        )
 
     # Create PSID header
     header = PSIDHeader(
@@ -364,6 +388,16 @@ def main():
     )
     parser.add_argument('input_sf2', help='Input SF2 file')
     parser.add_argument('output_sid', help='Output SID file')
+    parser.add_argument(
+        '--init', type=lambda s: int(s, 0), default=None,
+        help='Override the detected init address (e.g. 0x1000). '
+             'Required for bin/-only native drivers, whose addresses cannot '
+             'be auto-detected.'
+    )
+    parser.add_argument(
+        '--play', type=lambda s: int(s, 0), default=None,
+        help='Override the detected play address (e.g. 0x1003).'
+    )
 
     # Enhanced logging arguments (v2.0.0)
     parser.add_argument(
@@ -400,7 +434,9 @@ def main():
 
     try:
         with PerformanceLogger(logger, f"SF2 to SID conversion: {args.input_sf2}"):
-            success = convert_sf2_to_sid(args.input_sf2, args.output_sid)
+            success = convert_sf2_to_sid(args.input_sf2, args.output_sid,
+                                          init_override=args.init,
+                                          play_override=args.play)
 
         if success:
             logger.info("Conversion complete!")

--- a/sidm2/audio_export_wrapper.py
+++ b/sidm2/audio_export_wrapper.py
@@ -75,7 +75,9 @@ class AudioExportIntegration:
         stereo: bool = True,
         fade_out: int = DEFAULT_FADE_OUT,
         verbose: int = 0,
-        force_sid2wav: bool = False
+        force_sid2wav: bool = False,
+        mute_voices: Optional[str] = None,
+        subtune: Optional[int] = None
     ) -> Optional[Dict[str, Any]]:
         """
         Export SID file to WAV audio.
@@ -93,6 +95,11 @@ class AudioExportIntegration:
             fade_out: Fade-out time in seconds (default: 2, SID2WAV only)
             verbose: Verbosity level (0=quiet, 1=normal, 2=debug)
             force_sid2wav: Force use of SID2WAV even if VSID is available
+            mute_voices: SID2WAV -m<num> voice-mute string (e.g. "23" mutes
+                voices 2+3). SID2WAV-only -- VSID has no equivalent, so this
+                requires force_sid2wav=True.
+            subtune: SID2WAV -o<num> song/subtune number. SID2WAV-only, same
+                force_sid2wav=True requirement as mute_voices.
 
         Returns:
             Dictionary with export results:
@@ -109,6 +116,18 @@ class AudioExportIntegration:
             }
             Returns None if no tool available.
         """
+        if mute_voices is not None and not force_sid2wav:
+            raise ValueError(
+                "mute_voices requires force_sid2wav=True -- VSID has no "
+                "voice-mute equivalent, so silently ignoring the flag would "
+                "produce a misleading (unmuted) render."
+            )
+        if subtune is not None and not force_sid2wav:
+            raise ValueError(
+                "subtune requires force_sid2wav=True -- VSID export has no "
+                "subtune-select equivalent in this wrapper."
+            )
+
         # Try VSID first (preferred) unless forced to use SID2WAV
         if not force_sid2wav and AudioExportIntegration.PREFER_VSID and VSID_AVAILABLE:
             if verbose > 1:
@@ -167,6 +186,14 @@ class AudioExportIntegration:
                 f"-f{frequency}",  # Frequency
                 f"-fout{fade_out}",  # Fade-out
             ]
+
+            # Voice mute (e.g. "23" mutes voices 2+3)
+            if mute_voices:
+                args.append(f"-m{mute_voices}")
+
+            # Subtune/song select
+            if subtune is not None:
+                args.append(f"-o{subtune}")
 
             # Bit depth
             if bit_depth == 16:

--- a/sidm2/audio_tightness.py
+++ b/sidm2/audio_tightness.py
@@ -1,0 +1,311 @@
+"""Audio-domain "tightness" measurement: onset timing + attack-shape comparison.
+
+Register-write-exact trace comparison (trace_comparison_tool.py,
+accuracy_heatmap_tool.py) is SIDM2's primary fidelity measure, but a
+register match can still sound "not tight" to a human ear -- a verified,
+97%+ register-exact Blackbird build (docs/players/BLACKBIRD.md's B13 entry)
+still drew "something with the perc or drums" from a real listening pass,
+with no dip in the register score to flag it. This module gives that
+complaint a number: do note/drum onsets land at the same time, with the
+same attack shape, as the original.
+
+Pure array-in/array-out -- no subprocess, no file I/O except load_wav_mono
+and analyze_tightness_files, so the rest is testable without VICE/SID2WAV
+installed. Generalizes bin/listen_compare.py's get_audio()/logmel() (NOT
+imported from there -- that file is Galway-digi-coupled) to onset detection
+rather than continuous pitch tracking.
+"""
+import wave
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union
+
+import numpy as np
+
+
+@dataclass
+class Onset:
+    t: float
+
+
+@dataclass
+class OnsetMatch:
+    orig_t: float
+    driver_t: float
+    delta_ms: float
+    rise_delta_ms: float
+    spectral_dist: float
+    loose: bool
+
+
+@dataclass
+class TightnessReport:
+    orig_onsets: List[Onset]
+    driver_onsets: List[Onset]
+    matched: List[OnsetMatch]
+    missing: List[float]
+    extra: List[float]
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+def load_wav_mono(path: Union[str, Path]) -> Tuple[np.ndarray, int]:
+    """Load a WAV file as mono float32 in [-1, 1]. Generalized from
+    bin/listen_compare.py's get_audio(), minus the render step."""
+    with wave.open(str(path), 'rb') as w:
+        sr = w.getframerate()
+        ch = w.getnchannels()
+        sampwidth = w.getsampwidth()
+        raw = w.readframes(w.getnframes())
+
+    if sampwidth == 2:
+        x = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    elif sampwidth == 1:
+        x = (np.frombuffer(raw, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+    else:
+        raise ValueError(f"Unsupported WAV sample width: {sampwidth} bytes ({path})")
+
+    if ch > 1:
+        x = x.reshape(-1, ch).mean(axis=1)
+    return x, sr
+
+
+def band_energies(x: np.ndarray, sr: int, hop_s: float = 0.01, win_s: float = 0.04,
+                   nb: int = 40, fmin: float = 30, fmax: float = 8000) -> np.ndarray:
+    """Frame-hopped generalization of listen_compare.py's logmel(): linear
+    (not log) per-band energy per hop, shape (n_frames, nb)."""
+    hop = max(1, int(round(hop_s * sr)))
+    win = max(2, int(round(win_s * sr)))
+    n_frames = max(0, (len(x) - win) // hop + 1)
+    if n_frames == 0:
+        return np.zeros((0, nb))
+
+    window = np.hanning(win)
+    freqs = np.fft.rfftfreq(win, 1.0 / sr)
+    edges = np.linspace(fmin, fmax, nb + 1)
+    bin_idx = [np.where((freqs >= edges[i]) & (freqs < edges[i + 1]))[0] for i in range(nb)]
+
+    energies = np.zeros((n_frames, nb), dtype=np.float64)
+    for i in range(n_frames):
+        seg = x[i * hop: i * hop + win] * window
+        mag = np.abs(np.fft.rfft(seg))
+        for b, idx in enumerate(bin_idx):
+            if idx.size:
+                energies[i, b] = mag[idx].sum()
+    return energies
+
+
+def spectral_flux(bands: np.ndarray) -> np.ndarray:
+    """Half-wave-rectified frame-to-frame band-energy delta, summed per frame."""
+    if len(bands) == 0:
+        return np.zeros(0)
+    diff = np.diff(bands, axis=0, prepend=bands[:1])
+    return np.clip(diff, 0, None).sum(axis=1)
+
+
+def pick_onsets(flux: np.ndarray, hop_s: float, median_window_s: float = 0.5,
+                 delta: float = 1.5, min_distance_s: float = 0.05) -> List[float]:
+    """Local median+MAD adaptive-threshold peak picking (Dixon-style), with
+    greedy min-distance suppression. Returns onset times in seconds.
+
+    Two separate windows: median_window_s is the (larger) background-statistics
+    window for the threshold; local-max detection uses a (smaller) window sized
+    off min_distance_s -- using the same window for both would make a frame's
+    "local max" status depend on unrelated onsets several onsets away.
+    """
+    n = len(flux)
+    if n == 0:
+        return []
+
+    stat_win = max(1, int(round(median_window_s / hop_s)))
+    min_dist = max(1, int(round(min_distance_s / hop_s)))
+    peak_win = max(1, min_dist // 2)
+
+    onsets = []
+    last_idx = -min_dist - 1
+    for i in range(n):
+        stat_lo = max(0, i - stat_win)
+        stat_hi = min(n, i + stat_win + 1)
+        stat_local = flux[stat_lo:stat_hi]
+        med = np.median(stat_local)
+        mad = np.median(np.abs(stat_local - med)) + 1e-9
+        threshold = med + delta * mad
+
+        if flux[i] <= 0 or flux[i] < threshold:
+            continue
+
+        peak_lo = max(0, i - peak_win)
+        peak_hi = min(n, i + peak_win + 1)
+        if flux[i] != flux[peak_lo:peak_hi].max():
+            continue
+
+        if (i - last_idx) < min_dist:
+            continue
+
+        onsets.append(i * hop_s)
+        last_idx = i
+    return onsets
+
+
+def detect_onsets(x: np.ndarray, sr: int, hop_ms: float = 10, window_ms: float = 40,
+                   bands: int = 40, freq_lo: float = 30, freq_hi: float = 8000,
+                   **peak_kwargs) -> List[float]:
+    """Chain band_energies -> spectral_flux -> pick_onsets. Wider band range
+    than listen_compare's 200-5000Hz (tuned for melodic pitch tracking);
+    percussive transients are broadband."""
+    hop_s = hop_ms / 1000.0
+    win_s = window_ms / 1000.0
+    bands_arr = band_energies(x, sr, hop_s=hop_s, win_s=win_s, nb=bands, fmin=freq_lo, fmax=freq_hi)
+    flux = spectral_flux(bands_arr)
+    return pick_onsets(flux, hop_s, **peak_kwargs)
+
+
+def align_onsets(orig: List[float], driver: List[float],
+                  tolerance_s: float) -> Tuple[List[Tuple[float, float]], List[float], List[float]]:
+    """Greedy nearest-neighbor alignment in orig time order. NOT globally
+    optimal for dense onset runs -- acceptable limitation for v1."""
+    orig = sorted(orig)
+    driver = sorted(driver)
+    used = [False] * len(driver)
+    pairs = []
+    missing = []
+
+    j_start = 0
+    for ot in orig:
+        while j_start < len(driver) and driver[j_start] < ot - tolerance_s:
+            j_start += 1
+
+        best_j, best_d = -1, None
+        j = j_start
+        while j < len(driver) and driver[j] <= ot + tolerance_s:
+            if not used[j]:
+                d = abs(driver[j] - ot)
+                if best_d is None or d < best_d:
+                    best_d, best_j = d, j
+            j += 1
+
+        if best_j >= 0:
+            used[best_j] = True
+            pairs.append((ot, driver[best_j]))
+        else:
+            missing.append(ot)
+
+    extra = [driver[i] for i in range(len(driver)) if not used[i]]
+    return pairs, missing, extra
+
+
+def attack_rise_time_ms(x: np.ndarray, sr: int, onset_t: float, window_s: float = 0.08) -> float:
+    """RMS envelope 10%->90%-of-local-peak rise time, in ms."""
+    start = int(round(onset_t * sr))
+    end = min(len(x), start + int(round(window_s * sr)))
+    if end - start < 4:
+        return 0.0
+
+    seg = x[start:end]
+    hop = max(1, int(round(0.001 * sr)))
+    win = max(2, int(round(0.003 * sr)))
+    n_frames = max(1, (len(seg) - win) // hop + 1)
+
+    env = np.zeros(n_frames)
+    for i in range(n_frames):
+        chunk = seg[i * hop: i * hop + win]
+        if chunk.size:
+            env[i] = np.sqrt(np.mean(chunk.astype(np.float64) ** 2))
+
+    peak = env.max()
+    if peak <= 0:
+        return 0.0
+
+    lo_hits = np.where(env >= 0.1 * peak)[0]
+    if lo_hits.size == 0:
+        return 0.0
+    lo_idx = lo_hits[0]
+
+    hi_hits = np.where(env >= 0.9 * peak)[0]
+    hi_hits = hi_hits[hi_hits >= lo_idx]
+    if hi_hits.size == 0:
+        return 0.0
+    hi_idx = hi_hits[0]
+
+    return float((hi_idx - lo_idx) * hop / sr * 1000.0)
+
+
+def _logmel(seg: np.ndarray, sr: int, nb: int = 24, fmin: float = 200, fmax: float = 5000) -> np.ndarray:
+    if len(seg) == 0:
+        return np.zeros(nb)
+    window = np.hanning(len(seg)) if len(seg) > 1 else np.ones(len(seg))
+    mag = np.abs(np.fft.rfft(seg * window))
+    freqs = np.fft.rfftfreq(len(seg), 1.0 / sr)
+    edges = np.linspace(fmin, fmax, nb + 1)
+    energies = np.array([
+        mag[(freqs >= edges[i]) & (freqs < edges[i + 1])].sum()
+        for i in range(nb)
+    ])
+    total = energies.sum() + 1e-9
+    return np.log(energies / total + 1e-6)
+
+
+def logmel_distance(seg_a: np.ndarray, seg_b: np.ndarray, sr: int, nb: int = 24,
+                     fmin: float = 200, fmax: float = 5000) -> float:
+    """Generalized listen_compare.py::logmel() distance between two segments."""
+    la = _logmel(seg_a, sr, nb, fmin, fmax)
+    lb = _logmel(seg_b, sr, nb, fmin, fmax)
+    return float(np.abs(la - lb).mean())
+
+
+def analyze_tightness(orig: np.ndarray, driver: np.ndarray, sr: int,
+                       onset_tolerance_ms: float = 150, loose_threshold_ms: float = 40,
+                       **detector_kwargs) -> TightnessReport:
+    """Pure top-level entry point: two mono float arrays at the same sample
+    rate in, a TightnessReport out."""
+    orig_times = detect_onsets(orig, sr, **detector_kwargs)
+    driver_times = detect_onsets(driver, sr, **detector_kwargs)
+
+    tolerance_s = onset_tolerance_ms / 1000.0
+    pairs, missing, extra = align_onsets(orig_times, driver_times, tolerance_s)
+
+    rise_window_s = 0.08
+    matched = []
+    for ot, dt in pairs:
+        delta_ms = (dt - ot) * 1000.0
+        orig_rise = attack_rise_time_ms(orig, sr, ot, window_s=rise_window_s)
+        driver_rise = attack_rise_time_ms(driver, sr, dt, window_s=rise_window_s)
+
+        oa = int(round(ot * sr))
+        ob = int(round(dt * sr))
+        win = int(round(rise_window_s * sr))
+        seg_a = orig[oa:oa + win]
+        seg_b = driver[ob:ob + win]
+        spec_dist = logmel_distance(seg_a, seg_b, sr) if seg_a.size and seg_b.size else float('nan')
+
+        matched.append(OnsetMatch(
+            orig_t=ot,
+            driver_t=dt,
+            delta_ms=delta_ms,
+            rise_delta_ms=driver_rise - orig_rise,
+            spectral_dist=spec_dist,
+            loose=abs(delta_ms) > loose_threshold_ms,
+        ))
+
+    params = dict(onset_tolerance_ms=onset_tolerance_ms, loose_threshold_ms=loose_threshold_ms,
+                  **detector_kwargs)
+    return TightnessReport(
+        orig_onsets=[Onset(t=t) for t in orig_times],
+        driver_onsets=[Onset(t=t) for t in driver_times],
+        matched=matched,
+        missing=missing,
+        extra=extra,
+        params=params,
+    )
+
+
+def analyze_tightness_files(orig_wav_path: Union[str, Path], driver_wav_path: Union[str, Path],
+                             **kwargs) -> TightnessReport:
+    """File-based wrapper for the CLI. Raises on sample-rate mismatch."""
+    orig, sr_a = load_wav_mono(orig_wav_path)
+    driver, sr_b = load_wav_mono(driver_wav_path)
+    if sr_a != sr_b:
+        raise ValueError(
+            f"Sample rate mismatch: {orig_wav_path} is {sr_a} Hz, "
+            f"{driver_wav_path} is {sr_b} Hz"
+        )
+    return analyze_tightness(orig, driver, sr_a, **kwargs)


### PR DESCRIPTION
## Summary

- Register-write-exact trace comparison (`trace-compare.bat`, `accuracy-heatmap.bat`) can miss audio-domain problems a human ear catches immediately — a verified 97%+ register-exact Blackbird build (`docs/players/BLACKBIRD.md`'s B13 entry) still drew "something with the perc or drums" from a real listening pass, with no dip in the register score to flag it.
- Adds `audio-tightness.bat` / `pyscript/audio_tightness_tool.py`: renders an original `.sid` and a driver `.sf2`/`.sid`/`.wav` to WAV, detects onsets via a pure-numpy spectral-flux + adaptive peak-picking detector, aligns them, and reports onset-timing delta / attack-rise-time delta / spectral distance as text (for Claude) and HTML (waveform view + sortable onset table, for a human).
- Adds `--voice {1,2,3}` per-channel isolation via SID2WAV's `-m<num>` mute flag (confirmed directly against the binary — not previously wired up anywhere in the repo), applied identically to both renders for an apples-to-apples comparison.
- Fixes a related silent-failure mode in `scripts/sf2_to_sid.py`: `convert_sf2_to_sid()` would default-guess Driver 11's `$1000/$1006` init/play addresses when it couldn't detect them from the SF2 header — wrong for every `bin/`-only native driver (e.g. Blackbird is `$1000/$1003`, so the guess pointed at the driver's STOP routine instead of PLAY). Now tracks `address_source` and warns on the silent-guess path; added `--init`/`--play` overrides.

## Changes

- `sidm2/audio_tightness.py` — pure-numpy core: onset detection, greedy alignment, attack-rise-time and logmel-distance measurement (no I/O, fully unit-testable)
- `pyscript/audio_tightness_report.py` / `pyscript/audio_tightness_html_exporter.py` — text + HTML report generation, mirroring `accuracy_heatmap_exporter.py`'s dark-theme conventions via `html_components.py`
- `pyscript/audio_tightness_tool.py` + `audio-tightness.bat` — CLI entry point and launcher, mirroring `trace_comparison_tool.py`'s shape
- `scripts/sf2_to_sid.py` — `init_override`/`play_override` params, `address_source` tracking, `--init`/`--play` CLI flags (backward-compatible)
- `sidm2/audio_export_wrapper.py` — `mute_voices`/`subtune` passthrough to SID2WAV (requires `force_sid2wav=True`, since VSID has no equivalent)
- `pyscript/test_audio_tightness*.py` — 30 new tests against synthetic click-track fixtures, no VICE/SID2WAV required
- `requirements.txt` — declares `numpy>=1.24` (previously used ambiently but undeclared)
- `docs/guides/AUDIO_TIGHTNESS_GUIDE.md` — new user guide; one new line in `CLAUDE.md`'s Quick Commands

## Test plan

- [x] `python -m pytest pyscript/test_audio_tightness.py pyscript/test_audio_tightness_report.py pyscript/test_audio_tightness_html_exporter.py -q` — 30/30 pass
- [x] `python -m pytest pyscript/ -q --continue-on-collection-errors` — verified identical pass/fail/error counts before and after this change (54 failed / 1377 passed / 23 errors both times, via `git stash` A/B) — all pre-existing environment gaps (missing `psutil`/`py65`/`win32gui`, missing SID corpus files, a pre-existing `NameError` in `annotate_asm.py`, a pre-existing Python 3.11 f-string syntax issue), no regressions introduced
- [x] End-to-end CLI smoke test against synthetic WAV fixtures: correct onset/delta detection, correct error handling for missing files, unsupported extensions, and the `default_guess` address-detection failure path
- [x] Real build verification: ran `bin/build_blackbird_native_song.py SID/LFT/Glyptodont.sid` in this sandbox (installed `64tass` + `py65` for this) to confirm the native SF2 the tool is meant to analyze actually builds cleanly
- [ ] Full end-to-end acceptance run against real rendered audio (`audio-tightness.bat SID/LFT/Glyptodont.sid out/blackbird/Glyptodont_native_part01.sf2 --driver-init 0x1000 --driver-play 0x1003`) — SID2WAV.EXE only runs under wine in this remote Linux sandbox and renders far slower than real-time there, so this should be re-verified on a machine with native SID2WAV/VICE

---
_Generated by [Claude Code](https://claude.ai/code/session_014TLjDiwXW7qxezHUNVQhnK)_